### PR TITLE
MediaWiki 1.35 support

### DIFF
--- a/includes/Skin2018.php
+++ b/includes/Skin2018.php
@@ -6,33 +6,5 @@
  */
 class Skin2018 extends SkinTemplate {
 	public $skinname = '2018';
-	public $stylename = '2018';
 	public $template = 'Skin2018Template';
-
-	/**
-	 * Add CSS via ResourceLoader
-	 *
-	 * @param $out OutputPage
-	 */
-	public function initPage( OutputPage $out ) {
-		$out->addMeta( 'viewport', 'width=device-width, initial-scale=1.0' );
-
-		$out->addModuleStyles( [
-			// 'mediawiki.skinning.elements',
-			// 'mediawiki.skinning.content',
-			// 'mediawiki.skinning.interface',
-			'mediawiki.skinning.content.externallinks',
-			'skins.2018'
-		 ] );
-		$out->addModules( [
-			'skins.2018.js'
-		 ] );
-	}
-
-	/**
-	 * @param $out OutputPage
-	 */
-	function setupSkinUserCss( OutputPage $out ) {
-		parent::setupSkinUserCss( $out );
-	}
 }

--- a/includes/Skin2018Template.php
+++ b/includes/Skin2018Template.php
@@ -12,10 +12,10 @@ class Skin2018Template extends BaseTemplate {
 		// Rearrange parts of $this->data for easier handling in the template
 		unset( $this->data['nav_urls']['mainpage'] );
 		if ( isset( $this->data['content_navigation']['actions']['watch'] ) ) {
-			$this->data['watch_indicator']['watch'] = $this->data['content_navigation']['actions']['watch'];
+			$this->data['watch_indicator'] = $this->data['content_navigation']['actions']['watch'];
 			unset( $this->data['content_navigation']['actions']['watch'] );
 		} else {
-			$this->data['watch_indicator']['unwatch'] = $this->data['content_navigation']['actions']['unwatch'];
+			$this->data['watch_indicator'] = $this->data['content_navigation']['actions']['unwatch'];
 			unset( $this->data['content_navigation']['actions']['unwatch'] );
 		}
 

--- a/resources/templates/main.mustache
+++ b/resources/templates/main.mustache
@@ -57,7 +57,7 @@
                                 </div>
                                 <div>
                                     <ul class="uk-nav uk-navbar-dropdown-nav">
-                                        {{#each watch_indicator}}<li><a href="{{{href}}}">{{text}}</a></li>{{/watch_indicator}}
+                                        {{#watch_indicator}}<li><a href="{{{href}}}">{{text}}</a></li>{{/watch_indicator}}
                                         <li><a id="copy-permalink" data-clipboard-text="{{{serverurl}}}{{{nav_urls.permalink.href}}}">{{nav_urls.permalink.text}}</a></li>
                                         <li><a href="{{{nav_urls.upload.href}}}">Upload file</a></li>
                                         <li><a href="{{{content_navigation.actions.move.href}}}">{{content_navigation.actions.move.text}}</a></li>

--- a/skin.json
+++ b/skin.json
@@ -8,7 +8,22 @@
     "license-name": "MIT",
     "type": "skin",
     "ValidSkinNames": {
-        "2018": "2018"
+        "s2018": {
+            "class": "Skin2018",
+            "args": [
+                {
+                    "name": "2018",
+                    "responsive": true,
+                    "styles": [
+                        "mediawiki.skinning.content.externallinks",
+                        "skins.2018"
+                    ],
+                    "scripts": [
+                        "skins.2018.js"
+                    ]
+                }
+            ]
+        }
     },
     "MessagesDirs": {
         "2018": [
@@ -47,5 +62,5 @@
         "Skin2018": "includes/Skin2018.php",
         "Skin2018Template": "includes/Skin2018Template.php"
     },
-    "manifest_version": 1
+    "manifest_version": 2
 }


### PR DESCRIPTION
Nice skin! I've pushed a few patches to get this working with the latest 1.35. I'd like to put this up on skins.wmflabs.org as I think it's a really interesting idea for a skin.

Also note in 1.35 we added [SkinMustache](https://github.com/wikimedia/mediawiki/blob/master/includes/skins/SkinMustache.php) which may simplify a lot for you with your implementation here.

Changes:
* Our version of Mustache does not support the `for`  watch indicator
* The use of setupSkinUserCss is deprecated. Will break in future versions.
Use skin registration instead (much cleaner and available since 1.35)
* Prefix skin name with 's'. Skin keys that are numbers are not currently supported
* Update to manifest version 2