### PR TITLE
Fix skin "msg"s

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -2,6 +2,6 @@
     "@metadata": {
         "authors": ["Morag S."]
     },
-    "skinname-example": "2018",
-    "example-desc": "A contemporary theme utilizing off-the-shelf components for a clean UI and excellent readability"
+    "skinname-2018": "2018",
+    "2018-desc": "A contemporary theme utilizing off-the-shelf components for a clean UI and excellent readability"
 }

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -1,7 +1,7 @@
 {
     "@metadata": {
-        "authors": [ "..." ]
+        "authors": [ "Morag S." ]
     },
-    "skinname-example": "{{optional}}",
-    "example-desc": "{{desc|what=skin|name=Example|url=https://www.mediawiki.org/wiki/Skin:Example}}"
+    "skinname-2018": "{{optional}}",
+    "2018-desc": "{{desc|what=skin|name=2018|url=https://www.mediawiki.org/wiki/Skin:2018}}"
 }

--- a/skin.json
+++ b/skin.json
@@ -3,7 +3,7 @@
     "version": "0.1",
     "author": "Morag S.",
     "url": "https://www.mediawiki.org/wiki/Skin:2018",
-    "descriptionmsg": "A contemporary theme utilizing off-the-shelf components for a clean UI and excellent article readability",
+    "descriptionmsg": "2018-desc",
     "namemsg": "skinname-2018",
     "license-name": "MIT",
     "type": "skin",


### PR DESCRIPTION
The `descriptionmsg`  and `namemsg` keys in `skin.json` should match keys in `i18n/qqq.json` and `i18n/en.json`.

FYI: I noticed this issue at: [skins.toolforge.org](https://skins.toolforge.org/wiki/Special:Version#mw-version-skin).

See also:  jdlrobson/Alexandria#2.
